### PR TITLE
Response on review2

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogFormatter.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/RequestLogFormatter.scala
@@ -25,6 +25,15 @@ trait RequestLogFormatter {
 
   /**
    * Constructs the `String` to be logged by `ServletLogger` about this request.
+   * The resulted log line by default consists of:
+   *   - the request's method (GET, POST, etc.)
+   *   - the request's URL
+   *   - the IP address this request is coming from
+   *   - parameters sent with this request
+   *   - headers sent with this request
+   *
+   * Please note that no data in this log line is masked. If masking is required, please refer
+   * to the aggregated `MaskedLogFormatter` or the individual maskers in the `masked` package.
    *
    * @return the `String` to be logged
    */

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogFormatter.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ResponseLogFormatter.scala
@@ -23,10 +23,16 @@ import scala.collection.JavaConverters._
 trait ResponseLogFormatter {
   this: ScalatraBase =>
 
-  // TODO what is "this response"?
-  //  make clear that it might be more than the actionResult: the authHeaders
   /**
    * Constructs the `String` to be logged by `ServletLogger` about this response.
+   * The resulted log line by default consists of:
+   *   - the request's method (GET, POST, etc.)
+   *   - the status code of the `actionResult`
+   *   - headers sent with this response, originating from the `HttpServletResponse` instance
+   *   - headers sent with this response, originating from the `actionResult`
+   *
+   * Please note that no data in this log line is masked. If masking is required, please refer
+   * to the aggregated `MaskedLogFormatter` or the individual maskers in the `masked` package.
    *
    * @param actionResult the ActionResult to be logged
    * @return the `String` to be logged

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
@@ -93,8 +93,8 @@ trait AbstractServletLogger {
  *   class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging
  * }}}
  */
-trait ServletLogger extends AbstractServletLogger with RequestLogFormatter with ResponseLogFormatter {
-  this: ScalatraBase =>
+trait ServletLogger extends AbstractServletLogger {
+  this: ScalatraBase with RequestLogFormatter with ResponseLogFormatter =>
 
   protected val logger: Logger
 

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
@@ -48,7 +48,8 @@ trait AbstractServletLogger {
    * Performs the side effect of the logging of the response, contained in the given `ActionResult`.
    * This method is either called directly or via the extension method provided by
    * `LogResponseSyntax`.
-   * In differences in the spelled out examples are `Ok().logResponse` or `logResponse {Ok()}`.
+   * In the examples below the two syntaxes are shown. Please note that the only difference is
+   * `logResponse { Ok() }` vs. `Ok().logResponse`.
    *
    * @example
    * {{{

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/Masker.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/Masker.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.lib.logging.servlet.masked
 
 import nl.knaw.dans.lib.logging.servlet.{ HeaderMapEntry, MultiParamsEntry }
 
-private[masked] object Masker {
+object Masker {
 
   def formatCookie(value: String): String = {
     val cookieName = value.replaceAll("=.*", "")
@@ -46,8 +46,8 @@ private[masked] object Masker {
     remoteAddress.replaceAll("([0-9]+[.]){3}", "**.**.**.")
   }
 
-  def formatCookieHeader(headerName: String): HeaderMapEntry => HeaderMapEntry = {
-    formatTuple(_.toLowerCase == headerName)(formatCookie)
+  def formatCookieHeader(headerName: String)(formatter: String => String): HeaderMapEntry => HeaderMapEntry = {
+    formatTuple(_.toLowerCase == headerName)(formatter)
   }
 
   /**

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedCookie.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/request/MaskedCookie.scala
@@ -23,6 +23,6 @@ private[masked] trait MaskedCookie extends RequestLogExtensionBase {
   this: ScalatraBase =>
 
   abstract override protected def formatHeader(header: HeaderMapEntry): HeaderMapEntry = {
-    Masker.formatCookieHeader("cookie")(super.formatHeader(header))
+    Masker.formatCookieHeader("cookie")(Masker.formatCookie)(super.formatHeader(header))
   }
 }

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/response/MaskedSetCookie.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/masked/response/MaskedSetCookie.scala
@@ -23,6 +23,6 @@ private[masked] trait MaskedSetCookie extends ResponseLogExtensionBase {
   this: ScalatraBase =>
 
   abstract override protected def formatResponseHeader(header: HeaderMapEntry): HeaderMapEntry = {
-    Masker.formatCookieHeader("set-cookie")(super.formatResponseHeader(header))
+    Masker.formatCookieHeader("set-cookie")(Masker.formatCookie)(super.formatResponseHeader(header))
   }
 }

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
@@ -41,11 +41,15 @@ import org.scalatra.ActionResult
  * as well in order mask things like authorization headers, cookies, remote addresses and
  * authentication parameters.
  *
+ * When only parts of the request/response contain privacy sensitive data, the necessary individual
+ * parts of the `MaskedLogFormatter` can be added instead.
+ *
  * {{{
  *    import nl.knaw.dans.lib.logging.DebugEnhancedLogging
  *    import nl.knaw.dans.lib.logging.servlet._
  *    import org.scalatra.{ Ok, ScalatraServlet }
  *
+ *    // example with default logging of requests and responses
  *    class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging {
  *
  *      // I'd like to see a mandatory choice between a MaskedLogFormatter, a PlainLogFormatter or a CustomLogFormatter.
@@ -56,7 +60,16 @@ import org.scalatra.ActionResult
  *      }
  *    }
  *
+ *    // example with masked logging
  *    class MaskedServlet extends ScalatraServlet with ServletLogger with MaskedLogFormatter with DebugEnhancedLogging {
+ *      get("/") {
+ *        Ok("All is well").logResponse
+ *      }
+ *    }
+ *
+ *    // example with masking for only the remote address (request) and remote user (response)
+ *    import nl.knaw.dans.lib.logging.servlet.masked._
+ *    class MaskedServlet extends ScalatraServlet with ServletLogger with MaskedRemoteAddress with MaskedRemoteUser with DebugEnhancedLogging {
  *      get("/") {
  *        Ok("All is well").logResponse
  *      }

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
@@ -34,16 +34,14 @@ import org.scalatra.{ ActionResult, ScalatraBase }
  *
  * ==Usage==
  * To enable servlet logging, add the `ServletLogger` trait to the servlet definition, together with
- * a `RequestLogFormatter` and `ResponseLogFormatter` implementation (by default `PlainLogFormatter`)
- * and an implementation of a `com.typesafe.scalalogging.Logger`. In the example below we use
- * `DebugEnhancedLogging` for the latter.
+ * a `RequestLogFormatter`, a `ResponseLogFormatter` and a `com.typesafe.scalalogging.Logger`.
  *
- * When the request/response contain privacy sensitive data, a `MaskedLogFormatter` might be used
- * instead of `PlainLogFormatter` in order to mask things like authorization headers, cookies,
- * remote addresses and authentication parameters.
+ * In the example below we use `DebugEnhancedLogging` for the latter. The `PlainLogFormatter`
+ * and `MaskedLogFormatter` both implement the two LogFormatters. The latter masks privacy sensitive
+ * values like user names, passwords and remote addresses.
  *
- * When only parts of the request/response contain privacy sensitive data, the necessary individual
- * parts of the `MaskedLogFormatter` can be added instead in combination with the `PlainLogFormatter`.
+ * When you want to mask less, for example to debug tests, add individual
+ * parts of the `MaskedLogFormatter` to the `PlainLogFormatter`.
  *
  * {{{
  *    import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -89,16 +87,12 @@ import org.scalatra.{ ActionResult, ScalatraBase }
  *
  * ==Extension==
  *
- * // This example is a bridge too far.
- * // The typical use case would be a variation or mix of the PlainLogFormatter and/or the MaskedLogFormatter.
- * // A CustomLogFormatter could extend a mix of Plain/Masked/Custom-Request/Response-LogFormatter.
- * // The Custom-Request/Response-LogFormatter in turn can mix Plain/Masked/Custom traits.
- *
- * To write custom extensions to the log formatter, create a trait that extends either `RequestLogExtensionBase`
- * or `ResponseLogExtensionBase`. In this trait, implement the desired method (`formatHeader`, `formatParameter`,
- * `formatResponseHeader` or `formatActionHeader`), using an `abstract override` (which is important for mixing in
- * this formatter with the others). Keep in mind that the formatter should only return a formatted version of the
- * input and not mutate or perform side effects on it.
+ * For a variant of a `MaskedLogFormatter` component you can create a trait that extends either
+ * `RequestLogExtensionBase` or `ResponseLogExtensionBase`. In this trait, implement the desired
+ * method (`formatHeader`, `formatParameter`, `formatResponseHeader` or `formatActionHeader`),
+ * using an `abstract override` (which is important for mixing in this formatter with the others).
+ * Keep in mind that the formatter should only return a formatted version of the input and not
+ * mutate or perform side effects on it.
  *
  * {{{
  *    trait MyCustomRequestHeaderFormatter extends RequestLogExtensionBase {

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.lib.logging
 
-import org.scalatra.ActionResult
+import org.scalatra.{ ActionResult, ScalatraBase }
 
 /**
  * Package for logging servlet requests and responses in a standardized format.
@@ -33,27 +33,28 @@ import org.scalatra.ActionResult
  * header to some responses.
  *
  * ==Usage==
- * To enable servlet logging, add the `ServletLogger` trait to servlet definition, together with
- * an implementation of a `com.typesafe.scalalogging.Logger`. In the example below we use
+ * To enable servlet logging, add the `ServletLogger` trait to the servlet definition, together with
+ * a `RequestLogFormatter` and `ResponseLogFormatter` implementation (by default `PlainLogFormatter`)
+ * and an implementation of a `com.typesafe.scalalogging.Logger`. In the example below we use
  * `DebugEnhancedLogging` for the latter.
  *
- * When the request/response contain privacy sensitive data, a `MaskedLogFormatter` might be added
- * as well in order mask things like authorization headers, cookies, remote addresses and
- * authentication parameters.
+ * When the request/response contain privacy sensitive data, a `MaskedLogFormatter` might be used
+ * instead of `PlainLogFormatter` in order to mask things like authorization headers, cookies,
+ * remote addresses and authentication parameters.
  *
  * When only parts of the request/response contain privacy sensitive data, the necessary individual
- * parts of the `MaskedLogFormatter` can be added instead.
+ * parts of the `MaskedLogFormatter` can be added instead in combination with the `PlainLogFormatter`.
  *
  * {{{
  *    import nl.knaw.dans.lib.logging.DebugEnhancedLogging
  *    import nl.knaw.dans.lib.logging.servlet._
  *    import org.scalatra.{ Ok, ScalatraServlet }
  *
- *    // example with default logging of requests and responses
- *    class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging {
- *
- *      // I'd like to see a mandatory choice between a MaskedLogFormatter, a PlainLogFormatter or a CustomLogFormatter.
- *      // Not implicitly a plain log formatter.
+ *    // example with plain logging of requests and responses
+ *    class ExampleServlet extends ScalatraServlet
+ *      with ServletLogger
+ *      with PlainLogFormatter
+ *      with DebugEnhancedLogging {
  *
  *      get("/") {
  *        Ok("All is well").logResponse
@@ -61,7 +62,11 @@ import org.scalatra.ActionResult
  *    }
  *
  *    // example with masked logging
- *    class MaskedServlet extends ScalatraServlet with ServletLogger with MaskedLogFormatter with DebugEnhancedLogging {
+ *    class MaskedServlet extends ScalatraServlet
+ *      with ServletLogger
+ *      with MaskedLogFormatter
+ *      with DebugEnhancedLogging {
+ *
  *      get("/") {
  *        Ok("All is well").logResponse
  *      }
@@ -69,7 +74,13 @@ import org.scalatra.ActionResult
  *
  *    // example with masking for only the remote address (request) and remote user (response)
  *    import nl.knaw.dans.lib.logging.servlet.masked._
- *    class MaskedServlet extends ScalatraServlet with ServletLogger with MaskedRemoteAddress with MaskedRemoteUser with DebugEnhancedLogging {
+ *    class MaskedServlet extends ScalatraServlet
+ *      with ServletLogger
+ *      with PlainLogFormatter
+ *      with MaskedRemoteAddress
+ *      with MaskedRemoteUser
+ *      with DebugEnhancedLogging {
+ *
  *      get("/") {
  *        Ok("All is well").logResponse
  *      }
@@ -106,7 +117,12 @@ import org.scalatra.ActionResult
  *      }
  *    }
  *
- *    class ExampleServlet extends ScalatraServlet with ServletLogger with MyCustomRequestHeaderFormatter with DebugEnhancedLogging {
+ *    class ExampleServlet extends ScalatraServlet
+ *      with ServletLogger
+ *      with PlainLogFormatter
+ *      with MyCustomRequestHeaderFormatter
+ *      with DebugEnhancedLogging {
+ *
  *      get("/") {
  *        Ok("All is well").logResponse
  *      }
@@ -167,6 +183,10 @@ package object servlet {
     def logResponse(implicit responseLogger: AbstractServletLogger): ActionResult = {
       responseLogger.logResponse(actionResult)
     }
+  }
+
+  trait PlainLogFormatter extends RequestLogFormatter with ResponseLogFormatter {
+    this: ScalatraBase =>
   }
 
   type MaskedLogFormatter = masked.MaskedLogFormatter

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/ExampleServlets.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/ExampleServlets.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.logging.servlet
+
+import nl.knaw.dans.lib.logging.servlet.masked._
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.scalatra.{ Ok, ScalatraServlet }
+
+class PlainLogServlet extends ScalatraServlet
+  with ServletLogger
+  with PlainLogFormatter
+  with DebugEnhancedLogging {
+
+  get("/") {
+    Ok("foobar").logResponse
+  }
+}
+
+class MaskedLogServlet extends ScalatraServlet
+  with ServletLogger
+  with MaskedLogFormatter
+  with DebugEnhancedLogging {
+
+  get("/") {
+    Ok("foobar").logResponse
+  }
+}
+
+class PartiallyMaskedLogServlet extends ScalatraServlet
+  with ServletLogger
+  with PlainLogFormatter
+  with MaskedRemoteAddress
+  with MaskedRemoteUser
+  with DebugEnhancedLogging {
+
+  get("/") {
+    Ok("foobar").logResponse
+  }
+}

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/ServletLoggerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/ServletLoggerSpec.scala
@@ -27,7 +27,7 @@ class ServletLoggerSpec extends FlatSpec with Matchers with MockFactory with Ser
 
   private val mockedLogger = mock[Underlying]
 
-  private trait TestLogger extends ServletLogger {
+  private trait TestLogger extends ServletLogger with PlainLogFormatter {
     this: ScalatraBase =>
 
     override protected val logger: Logger = Logger(mockedLogger)

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/MaskSpecificCookieServlet.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/MaskSpecificCookieServlet.scala
@@ -1,0 +1,40 @@
+package nl.knaw.dans.lib.logging.servlet.examples
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.logging.servlet._
+import nl.knaw.dans.lib.logging.servlet.masked.Masker
+import org.scalatra.{ Ok, ScalatraBase, ScalatraServlet }
+
+trait NamedCookieMasker extends RequestLogExtensionBase with ResponseLogExtensionBase {
+  this: ScalatraBase =>
+
+  abstract override protected def formatHeader(header: HeaderMapEntry): HeaderMapEntry = {
+    Masker.formatCookieHeader("cookie")(formatCookie)(super.formatHeader(header))
+  }
+
+  abstract override protected def formatResponseHeader(header: HeaderMapEntry): HeaderMapEntry = {
+    Masker.formatCookieHeader("set-cookie")(formatCookie)(super.formatResponseHeader(header))
+  }
+
+  private def formatCookie(value: String): String = {
+    val cookieName = value.replaceAll("=.*", "")
+    if (cookieName == "my-cookie") {
+      val cookieValue = value.replaceFirst("[^=]+=", "")
+      // replace sequences of chars without dots
+      val maskedCookieValue = cookieValue.replaceAll("[^.]+", "****")
+      s"$cookieName=$maskedCookieValue"
+    }
+    else value
+  }
+}
+
+class MaskSpecificCookieServlet extends ScalatraServlet
+  with ServletLogger
+  with PlainLogFormatter
+  with NamedCookieMasker
+  with DebugEnhancedLogging {
+
+  get("/") {
+    Ok("foobar").logResponse
+  }
+}

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/MaskedLogServlet.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/MaskedLogServlet.scala
@@ -1,0 +1,15 @@
+package nl.knaw.dans.lib.logging.servlet.examples
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.logging.servlet._
+import org.scalatra.{ Ok, ScalatraServlet }
+
+class MaskedLogServlet extends ScalatraServlet
+  with ServletLogger
+  with MaskedLogFormatter
+  with DebugEnhancedLogging {
+
+  get("/") {
+    Ok("foobar").logResponse
+  }
+}

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/PartiallyMaskedLogServlet.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/PartiallyMaskedLogServlet.scala
@@ -13,31 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.lib.logging.servlet
+package nl.knaw.dans.lib.logging.servlet.examples
 
-import nl.knaw.dans.lib.logging.servlet.masked._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.logging.servlet._
+import nl.knaw.dans.lib.logging.servlet.masked._
 import org.scalatra.{ Ok, ScalatraServlet }
-
-class PlainLogServlet extends ScalatraServlet
-  with ServletLogger
-  with PlainLogFormatter
-  with DebugEnhancedLogging {
-
-  get("/") {
-    Ok("foobar").logResponse
-  }
-}
-
-class MaskedLogServlet extends ScalatraServlet
-  with ServletLogger
-  with MaskedLogFormatter
-  with DebugEnhancedLogging {
-
-  get("/") {
-    Ok("foobar").logResponse
-  }
-}
 
 class PartiallyMaskedLogServlet extends ScalatraServlet
   with ServletLogger

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/PlainLogServlet.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/PlainLogServlet.scala
@@ -1,0 +1,15 @@
+package nl.knaw.dans.lib.logging.servlet.examples
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.logging.servlet._
+import org.scalatra.{ Ok, ScalatraServlet }
+
+class PlainLogServlet extends ScalatraServlet
+  with ServletLogger
+  with PlainLogFormatter
+  with DebugEnhancedLogging {
+
+  get("/") {
+    Ok("foobar").logResponse
+  }
+}

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/masked/MaskerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/masked/MaskerSpec.scala
@@ -39,18 +39,18 @@ class MaskerSpec extends FlatSpec with Matchers {
 
   "formatCookieHeader" should "format a cookie with given header name" in {
     val cookieName = "my-cookie"
-    Masker.formatCookieHeader(cookieName)(cookieName -> Seq(cookie)) shouldBe
+    Masker.formatCookieHeader(cookieName)(Masker.formatCookie)(cookieName -> Seq(cookie)) shouldBe
       cookieName -> Seq(s"$cookieKey=****.****.****")
   }
 
   it should "format a cookie with given header name (after lowercasing)" in {
     val cookieName = "my-cookie"
-    Masker.formatCookieHeader(cookieName)(cookieName.toUpperCase -> Seq(cookie)) shouldBe
+    Masker.formatCookieHeader(cookieName)(Masker.formatCookie)(cookieName.toUpperCase -> Seq(cookie)) shouldBe
       cookieName.toUpperCase -> Seq(s"$cookieKey=****.****.****")
   }
 
   it should "not format a header with another name than the given one" in {
-    Masker.formatCookieHeader("my-cookie")("other-header" -> Seq("some value")) shouldBe
+    Masker.formatCookieHeader("my-cookie")(Masker.formatCookie)("other-header" -> Seq("some value")) shouldBe
       "other-header" -> Seq("some value")
   }
 


### PR DESCRIPTION
This is a response to the remarks/questions raised in https://github.com/rvanheest-DANS-KNAW/dans-scala-lib/pull/5.

* [x] clarifying 'this request' and 'this response' in the documentation of `RequestLogFormatter` and `ResponseLogFormatter`
* [x] clarifying the differences in the examples listed in `AbstractServletLogger.logResponse`
* [x] adding an extra example on how to mask only parts of the request/response
* [x] explicit plain log formatter
* [x] clarify 'Extension' example